### PR TITLE
Corretly set random seed on Erlang 17 and earlier

### DIFF
--- a/src/tdiff_benchmark.erl
+++ b/src/tdiff_benchmark.erl
@@ -200,14 +200,10 @@ rand_seed(Opts) ->
 %% Erlang 18 or earlier
 rand_uniform(Limit) -> random:uniform(Limit).
 rand_uniform() -> random:uniform().
-rand_seed() ->
-    {A, B, C} = os:timestamp(),
-    random:seed(erlang:phash2(A+B+C), erlang:phash2(B+C), erlang:phash2(A+C)).
-
 rand_seed(Opts) ->
     Seed = proplists:get_value(random_seed, Opts, random:seed0()),
     set_random_seed(Seed).
 
 set_random_seed({A,B,C}) ->
-    random_seed(A,B,C).
+    random:seed(A,B,C).
 -endif. % NO_HAVE_RAND


### PR DESCRIPTION
The benchmark code did not compile on Erlang 17 and earlier because of a missing call to `random:seed/1`. This pull request fixes that.

Example of failed compilation: https://travis-ci.org/eproxus/unite/jobs/264258400